### PR TITLE
Remove proposal_settings_editable setting from partitioning

### DIFF
--- a/control/control.SMO.xml
+++ b/control/control.SMO.xml
@@ -107,7 +107,6 @@ textdomain="control"
 
         <proposal>
             <lvm config:type="boolean">false</lvm>
-            <proposal_settings_editable config:type="boolean">true</proposal_settings_editable>
             <windows_delete_mode config:type="symbol">all</windows_delete_mode>
             <linux_delete_mode config:type="symbol">all</linux_delete_mode>
             <other_delete_mode config:type="symbol">all</other_delete_mode>

--- a/package/skelcd-control-SMO.changes
+++ b/package/skelcd-control-SMO.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  4 12:26:52 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not use proposal_settings_editable, which does not validate
+  because it is does not exist in storage-ng (bsc#1171423).
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Feb  3 08:10:57 UTC 2021 - jsrain@suse.com
 
 - install the hardware pattern by default

--- a/package/skelcd-control-SMO.spec
+++ b/package/skelcd-control-SMO.spec
@@ -27,7 +27,7 @@
 
 
 Name:           skelcd-control-SMO
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Summary:        The SUSEM MicroOS Installation Control file
 License:        MIT


### PR DESCRIPTION
## Problem

rpm [cannot be build](https://github.com/yast/skelcd-control-SMO/runs/1830306380?check_suite_focus=true#step:5:72) because of validations

```
RPM build errors:
Relax-NG validity error : Extra element partitioning in interleave
control.SMO.xml:105: element partitioning: Relax-NG validity error : Element productDefines failed to validate content
control.SMO.xml fails to validate
make: *** [Makefile:3: check] Error 3
```

More precisely because the `proposal_settings_editable`, according to the jing output

```
control.SMO.xml:110:63: error: element "proposal_settings_editable" not allowed here; expected the element end-tag or element "allocate_volume_mode", "delete_resize_configurable", "linux_delete_mode", "lvm_vg_size", "lvm_vg_strategy", "multidisk_first", "other_delete_mode", "resize_windows", "separate_vgs" or "windows_delete_mode"
```

## Solution

Remove such settings, which does not exist in storage-ng. See https://bugzilla.suse.com/show_bug.cgi?id=1171423 for more info.