### PR TITLE
Add SELinux settings

### DIFF
--- a/control/control.SMO.xml
+++ b/control/control.SMO.xml
@@ -70,6 +70,10 @@ textdomain="control"
         <!-- bnc #431158: Adjusts /etc/sysconfig/security/POLKIT_DEFAULT_PRIVS if set -->
         <polkit_default_privs>restrictive</polkit_default_privs>
 
+        <!-- jsc#SLE-17427: Makes a SELinux proposal, using enforcing by default -->
+        <selinux_mode>enforcing</selinux_mode>
+        <selinux_configurable config:type="boolean">true</selinux_configurable>
+
     </globals>
 
     <software>

--- a/package/skelcd-control-SMO.changes
+++ b/package/skelcd-control-SMO.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb  5 14:57:56 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Set an "enforcing" SELinux proposal (jsc#SLE-17427).
+- 5.0.3
+
+-------------------------------------------------------------------
 Fri Feb  5 01:59:25 UTC 2021 - jsrain@suse.com
 
 - install the microos-selinux pattern by default (bsc#1181714)

--- a/package/skelcd-control-SMO.spec
+++ b/package/skelcd-control-SMO.spec
@@ -40,8 +40,8 @@ Source:         skelcd-control-SMO-%{version}.tar.bz2
 BuildRequires:  libxml2-tools
 # xsltproc
 BuildRequires:  libxslt-tools
-# RNG schema
-BuildRequires:  yast2-installation-control
+# RNG schema: selinux_mode and selinux_configurable introduced in 4.2.11
+BuildRequires:  yast2-installation-control >= 4.2.11
 # Generic Yast packages needed for the installer
 Requires:       autoyast2
 Requires:       yast2-add-on

--- a/package/skelcd-control-SMO.spec
+++ b/package/skelcd-control-SMO.spec
@@ -27,7 +27,7 @@
 
 
 Name:           skelcd-control-SMO
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 Summary:        The SUSEM MicroOS Installation Control file
 License:        MIT


### PR DESCRIPTION
Enables a SELinux proposal, setting the `enforcing` mode by default.

Related to 

* https://github.com/yast/yast-security/pull/83
* https://github.com/yast/yast-firewall/pull/144
* https://github.com/yast/yast-installation-control/pull/107
* https://trello.com/c/g94xQBDM (internal link)
* https://jira.suse.com/browse/SLE-17427 (internal link)