### PR TITLE
Fix Rakefile (in master branch)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle15sp2
-
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/


### PR DESCRIPTION
In master the `submit_to` can be omitted, `sle15sp2` value was there for the SLE-15-SP2 branch.