### PR TITLE
Adjust SELinux variables

### DIFF
--- a/control/control.SMO.xml
+++ b/control/control.SMO.xml
@@ -70,9 +70,12 @@ textdomain="control"
         <!-- bnc #431158: Adjusts /etc/sysconfig/security/POLKIT_DEFAULT_PRIVS if set -->
         <polkit_default_privs>restrictive</polkit_default_privs>
 
-        <!-- jsc#SLE-17427: Makes a SELinux proposal, using enforcing by default -->
-        <selinux_mode>enforcing</selinux_mode>
-        <selinux_configurable config:type="boolean">true</selinux_configurable>
+        <!-- jsc#SLE-17342: Makes a SELinux proposal, using enforcing by default -->
+        <selinux>
+          <mode>enforcing</mode>
+          <configurable config:type="boolean">true</configurable>
+          <patterns>microos-selinux</patterns>
+        </selinux>
 
     </globals>
 

--- a/package/skelcd-control-SMO.changes
+++ b/package/skelcd-control-SMO.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 11 13:06:32 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Define selinux mode, configurable, and patterns values properly
+  (related to jsc#14342).
+- 5.0.4
+
+-------------------------------------------------------------------
 Fri Feb  5 14:57:56 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Set an "enforcing" SELinux proposal (jsc#SLE-17427).

--- a/package/skelcd-control-SMO.spec
+++ b/package/skelcd-control-SMO.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package skelcd-control-SMO
 #
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2021 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -30,10 +30,10 @@ Name:           skelcd-control-SMO
 Version:        5.0.4
 Release:        0
 Summary:        The SUSEM MicroOS Installation Control file
-License:        MIT
-Group:          Metapackages
 #
 ######################################################################
+License:        MIT
+Group:          Metapackages
 URL:            https://github.com/yast/skelcd-control-SMO
 Source:         skelcd-control-SMO-%{version}.tar.bz2
 # xmllint
@@ -93,7 +93,7 @@ Requires:       yast2-vm
 %endif
 
 # avoid file conflict with SLES package
-Obsoletes:	skelcd-control-leanos
+Obsoletes:      skelcd-control-leanos
 
 %description
 This package contains the control file used for SUSE MicroOS installation.

--- a/package/skelcd-control-SMO.spec
+++ b/package/skelcd-control-SMO.spec
@@ -27,7 +27,7 @@
 
 
 Name:           skelcd-control-SMO
-Version:        5.0.3
+Version:        5.0.4
 Release:        0
 Summary:        The SUSEM MicroOS Installation Control file
 License:        MIT

--- a/package/skelcd-control-SMO.spec
+++ b/package/skelcd-control-SMO.spec
@@ -40,8 +40,8 @@ Source:         skelcd-control-SMO-%{version}.tar.bz2
 BuildRequires:  libxml2-tools
 # xsltproc
 BuildRequires:  libxslt-tools
-# RNG schema: selinux_mode and selinux_configurable introduced in 4.2.11
-BuildRequires:  yast2-installation-control >= 4.2.11
+# RNG schema: grouped selinux variables
+BuildRequires:  yast2-installation-control >= 4.2.12
 # Generic Yast packages needed for the installer
 Requires:       autoyast2
 Requires:       yast2-add-on


### PR DESCRIPTION
Adjust SELinux variables to fit with the _new format_ introduced in https://github.com/yast/yast-installation-control/pull/108

I.e., to declare them as 

```xml
<selinux>
  <mode>enforcing</mode>
  ...
  <patterns>microos-selinux</patterns>
</selinux>
```

instead of 

```xml
<selinux_mode>enforcing</selinux_mode>
...
<selinux_patterns>microos-selinux</selinux_patterns>
```

---

It validates properly when `yast-installation-control` >= 4.2.12 installed. Manually tested

```
$ zypper info yast2-installation-control
  ...
  Information for package yast2-installation-control:
  ---------------------------------------------------
  Repository     : @System
  Name           : yast2-installation-control
  Version        : 4.2.12-1
  ...
$ jing /usr/share/YaST2/control/control.rng control/control.SMO.xml
  no errors output
$ xmllint --noout --relaxng /usr/share/YaST2/control/control.rng control/control.SMO.xml 
  control/control.SMO.xml validates
```