### PR TITLE
[SLE-Micro-5.2] Add missing glade link

### DIFF
--- a/control/control.SMO.glade
+++ b/control/control.SMO.glade
@@ -1,0 +1,1 @@
+control.SMO.xml

--- a/package/skelcd-control-SMO.changes
+++ b/package/skelcd-control-SMO.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 18 09:41:25 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Add missing .glade file to avoid a crash when checking
+  translations (bsc#1194803)
+- 5.2.1
+
+-------------------------------------------------------------------
 Mon Dec 20 18:47:59 UTC 2021 - jsrain@suse.com
 
 - append security=selinux to cmdline (bsc#1192347)

--- a/package/skelcd-control-SMO.spec
+++ b/package/skelcd-control-SMO.spec
@@ -27,9 +27,9 @@
 
 
 Name:           skelcd-control-SMO
-Version:        5.2.0
+Version:        5.2.1
 Release:        0
-Summary:        The SUSEM MicroOS Installation Control file
+Summary:        The SUSE MicroOS Installation Control file
 #
 ######################################################################
 License:        MIT


### PR DESCRIPTION
Add missing .glade file to avoid a crash when checking translations ([bsc#1194803](https://bugzilla.suse.com/show_bug.cgi?id=1194803))

---

Same as #20 and #21 but for `SLE-Micro-5.2` branch.

