### PR TITLE
Add missing .glade link to .xml file

### DIFF
--- a/control/control.SMO.glade
+++ b/control/control.SMO.glade
@@ -1,0 +1,1 @@
+control.SMO.xml


### PR DESCRIPTION
Note for the pull request authors:

The `master` branch is not in use. Please, make your PR against the right branch
(i.e., `SLE-Micro-${version}`).
Done in all active branches.

Please pull to master anyway. It breaks the yast-translations work-flow:

```
y2m read-only ALL
y2m pull
y2makepot
```
fails with

```
** ERROR: Missing textdomain in file /home/sbrabec/yast-checkout/skelcd-control-SMO/./control/control.SMO.glade
```

If you find a better way to collect translations, please let me know.