### PR TITLE
append 'apparmor=0' instead 'security=selinux'

### DIFF
--- a/control/control.SMO.xml
+++ b/control/control.SMO.xml
@@ -9,7 +9,7 @@ textdomain="control"
     <textdomain>control</textdomain>
 
     <globals>
-        <additional_kernel_parameters>swapaccount=1 security=selinux</additional_kernel_parameters>
+        <additional_kernel_parameters>swapaccount=1 apparmor=0</additional_kernel_parameters>
         <enable_autologin config:type="boolean">false</enable_autologin>
         <enable_firewall config:type="boolean">false</enable_firewall>
         <firewall_enable_ssh config:type="boolean">true</firewall_enable_ssh>

--- a/package/skelcd-control-SMO.changes
+++ b/package/skelcd-control-SMO.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Mar 25 12:07:40 UTC 2022 - jsrain@suse.com
+
+- append 'apparmor=0' instead 'security=selinux', because it gets
+  removed if YaST does not enable SELinux, resulting in AppArmor
+  being enabled (bsc#1197522)
+- 5.2.3
+
+-------------------------------------------------------------------
 Wed Jan 26 07:35:21 UTC 2022 - jsrain@suse.com
 
 - require specific AutoYaST schema (jsc#SLE-18820)

--- a/package/skelcd-control-SMO.spec
+++ b/package/skelcd-control-SMO.spec
@@ -27,7 +27,7 @@
 
 
 Name:           skelcd-control-SMO
-Version:        5.2.2
+Version:        5.2.3
 Release:        0
 Summary:        The SUSE MicroOS Installation Control file
 #


### PR DESCRIPTION
  because it gets removed if YaST does not enable SELinux, resulting in AppArmor
  being enabled (bsc#1197522)

Note for the pull request authors:

The `master` branch is not in use. Please, make your PR against the right branch
(i.e., `SLE-Micro-${version}`).
