### PR TITLE
Added "kdump" dependency

### DIFF
--- a/package/skelcd-control-SMO.changes
+++ b/package/skelcd-control-SMO.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul 26 14:46:35 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "kdump" dependency, yast2-kdump only has a runtime
+  depenency but the package is also needed in the inst-sys
+  (related to bsc#1199840)
+- 5.0.2
+
+-------------------------------------------------------------------
 Thu Feb  4 12:26:52 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Do not use proposal_settings_editable, which does not validate

--- a/package/skelcd-control-SMO.spec
+++ b/package/skelcd-control-SMO.spec
@@ -20,14 +20,14 @@
 #   in build service directly, use
 #   https://github.com/yast/skelcd-control-SMO repository
 #
-#   See https://github.com/yast/skelcd-control-SMO/blob/master/CONTRIBUTING.md
+#   See https://github.com/yast/.github/blob/master/CONTRIBUTING.md
 #   for more details.
 #
 ######################################################################
 
 
 Name:           skelcd-control-SMO
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 Summary:        The SUSEM MicroOS Installation Control file
 License:        MIT
@@ -56,6 +56,8 @@ Requires:       yast2-firewall
 Requires:       yast2-installation >= 3.1.217.9
 Requires:       yast2-iscsi-client
 Requires:       yast2-kdump
+# yast2-kdump has only runtime dependency but the package is also needed in the inst-sys
+Requires:       kdump
 Requires:       yast2-multipath
 Requires:       yast2-network >= 3.1.42
 Requires:       yast2-nfs-client


### PR DESCRIPTION
- Related to https://github.com/yast/yast-kdump/pull/128, `yast2-kdump` now uses a runtime dependency
- But we also need the `kdump` package in the inst-sys ([bsc#875765#c4](https://bugzilla.suse.com/show_bug.cgi?id=875765#c4))
- So add it explicitly here